### PR TITLE
fix: add nixpkgs-webstorm input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -257,6 +257,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-webstorm": {
+      "locked": {
+        "lastModified": 1753254436,
+        "narHash": "sha256-nyKERc57Zr5jBLegyKJNs2YCJGuITa55G0WbZkRtkCw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "64f9557cc1c67cf1aeabba870e31ba9705fd4315",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "pull/419026/head",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1752436162,
@@ -339,6 +355,7 @@
         "home-manager": "home-manager",
         "nh": "nh",
         "nixpkgs": "nixpkgs_3",
+        "nixpkgs-webstorm": "nixpkgs-webstorm",
         "stylix": "stylix"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -37,6 +37,10 @@
     nh = {
       url = "github:viperML/nh";
     };
+
+    nixpkgs-webstorm = {
+      url = "github:NixOS/nixpkgs/pull/419026/head";
+    };
   };
 
   outputs = {

--- a/home-manager/modules/home.nix
+++ b/home-manager/modules/home.nix
@@ -27,7 +27,7 @@
         nh
         bottles
         nerd-fonts.fira-code
-        jetbrains.webstorm
+        inputs."nixpkgs-webstorm".legacyPackages.${pkgs.system}.jetbrains.webstorm
         slack
         discord
         maim


### PR DESCRIPTION
## Summary
- add `nixpkgs-webstorm` input referencing Nixpkgs PR #419026
- use that input only for the WebStorm package

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688178ecfe888324bf0fc99d558afac2