### PR TITLE
ci: add Nix cache workflow with merging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,28 +2,47 @@ name: CI
 
 permissions:
   contents: write
+  actions: write
 
 on:
   pull_request:
 
 jobs:
-  check-and-format:
-    runs-on: ubuntu-latest
+  make-caches:
+    name: Build and cache
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        id: [1, 2]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true
-      - uses: cachix/install-nix-action@v31
+      - uses: nixbuild/nix-quick-install-action@v30
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-individual-${{ matrix.id }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-common-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          gc-max-store-size-linux: 1G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-individual-${{ matrix.id }}-
+          purge-created: 0
+          purge-last-accessed: 0
+          purge-primary-key: never
       - name: Nix flake check
         run: nix flake check -L
       - name: Format Nix code
         run: nix fmt .
       - name: Commit formatted changes
+        if: matrix.id == 1
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             git config user.name "github-actions[bot]"
@@ -32,3 +51,29 @@ jobs:
             git push origin HEAD:${{ github.head_ref }}
           fi
 
+  merge-caches:
+    name: Merge caches
+    needs: make-caches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+      - name: Merge Nix store caches
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-common-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-all-matches: |
+            nix-${{ runner.os }}-individual-1-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+            nix-${{ runner.os }}-individual-2-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          gc-max-store-size-linux: 1G
+          purge: true
+          purge-prefixes: |
+            nix-${{ runner.os }}-individual-
+            nix-${{ runner.os }}-common-
+          purge-created: 0
+          purge-last-accessed: 0
+          purge-primary-key: never


### PR DESCRIPTION
## Summary
- enable GitHub Actions cache permissions
- set up Nix install via nix-quick-install-action
- restore and save Nix store caches
- merge individual caches into a common cache after builds

## Testing
- `git commit -m "Add Nix cache workflow with merging"`


------
https://chatgpt.com/codex/tasks/task_e_6881822b986c8324a2169a89be7a775b