### PR TITLE
CI: build configs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,10 @@ jobs:
           purge-created: 0
           purge-last-accessed: 0
           purge-primary-key: never
-      - name: Nix flake check
-        run: nix flake check -L
+      - name: Build NixOS configuration
+        run: nix build .#nixosConfigurations.charon.config.system.build.toplevel
+      - name: Build home-manager configuration
+        run: nix build .#homeConfigurations."potb@charon".activationPackage
       - name: Format Nix code
         run: nix fmt .
       - name: Commit formatted changes


### PR DESCRIPTION
## Summary
- build the NixOS system and home-manager config in CI

## Testing
- `nix --extra-experimental-features 'nix-command flakes' fmt .`
- `nix --extra-experimental-features 'nix-command flakes' build .#nixosConfigurations.charon.config.system.build.toplevel --no-link --print-build-logs` *(fails: interrupted by the user)*
- `nix --extra-experimental-features 'nix-command flakes' build .#homeConfigurations."potb@charon".activationPackage --dry-run` *(fails: interrupted by the user)*

------
https://chatgpt.com/codex/tasks/task_e_68818480a69c8324be2f25f8cbd93998